### PR TITLE
Add cross-platform server launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,15 @@ cd prompt-generator
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 # 서버 시작 (대화형 메뉴)
-.\start_server.ps1
+.\start-servers.ps1
 
 # 또는 직접 실행
-.\start_server.ps1 -Both    # Frontend + Backend 동시 시작
-.\start_server.ps1 -BackendOnly   # Backend만 시작
-.\start_server.ps1 -FrontendOnly  # Frontend만 시작
+.\start-servers.ps1               # Frontend + Backend 동시 시작 (개발 모드)
+.\start-servers.ps1 -Backend false # Frontend만 시작
+.\start-servers.ps1 -Frontend false # Backend만 시작
+
+# Linux/macOS 환경
+./start-servers.sh                 # 프론트엔드와 백엔드 동시 시작
 ```
 
 ### 3️⃣ 브라우저 접속
@@ -88,7 +91,8 @@ prompt-generator/
 │   │   ├── App.tsx         # 메인 React 컴포넌트
 │   │   └── components/     # UI 컴포넌트들
 │   └── package.json        # Node.js 의존성
-└── start_server.ps1        # 서버 시작 스크립트
+├── start-servers.ps1       # Windows용 서버 시작 스크립트
+└── start-servers.sh        # Linux/macOS용 서버 시작 스크립트
 ```
 
 ## 🔌 API 엔드포인트

--- a/start-servers.sh
+++ b/start-servers.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Simple script to start frontend and backend servers together
+# Usage: ./start-servers.sh [dev|prod]
+
+set -e
+
+MODE="${1:-dev}"
+FRONTEND_PORT=5173
+BACKEND_PORT=5001
+
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+FRONTEND_DIR="$SCRIPT_DIR/frontend"
+BACKEND_DIR="$SCRIPT_DIR/backend"
+
+start_backend() {
+  echo "Starting backend server ($MODE) on port $BACKEND_PORT"
+  pushd "$BACKEND_DIR" >/dev/null
+  export FLASK_ENV=$([ "$MODE" = "prod" ] && echo "production" || echo "development")
+  export PORT=$BACKEND_PORT
+  python -m src.main &
+  BACKEND_PID=$!
+  popd >/dev/null
+}
+
+start_frontend() {
+  echo "Starting frontend server ($MODE) on port $FRONTEND_PORT"
+  pushd "$FRONTEND_DIR" >/dev/null
+  if [ ! -d node_modules ]; then
+    npm install
+  fi
+  if [ "$MODE" = "prod" ]; then
+    npm run build
+    npm run preview -- --host 0.0.0.0 --port $FRONTEND_PORT &
+  else
+    npm run dev -- --host 0.0.0.0 --port $FRONTEND_PORT &
+  fi
+  FRONTEND_PID=$!
+  popd >/dev/null
+}
+
+cleanup() {
+  echo "Stopping servers..."
+  kill $FRONTEND_PID $BACKEND_PID 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+start_backend
+start_frontend
+
+wait $BACKEND_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- add `start-servers.sh` for running backend and frontend together
- document new scripts in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'model_optimizer')*

------
https://chatgpt.com/codex/tasks/task_e_68406dad86488328a8cf6ac3d53bd829